### PR TITLE
move data fetch to server component

### DIFF
--- a/app/lib/services/vercelPostgres.ts
+++ b/app/lib/services/vercelPostgres.ts
@@ -1,5 +1,6 @@
 import { QueryResult, QueryResultRow, VercelClient, createClient } from '@vercel/postgres';
 import { repoArrayToObject } from '../util';
+import { repoData } from '../definitions';
 
 const newClient = (): VercelClient => {
 	return createClient({
@@ -7,7 +8,7 @@ const newClient = (): VercelClient => {
 	});
 }
 // TODO: setup api layer to fetch github info on server
-export const fetchRepoData = async () => {
+export const fetchRepoData = async (): Promise<repoData> => {
 	const client = newClient();
 	await client.connect();
 	const repositories: QueryResult<QueryResultRow> = await client.sql`select * from githubRepositories;`;

--- a/app/portfolio/page.tsx
+++ b/app/portfolio/page.tsx
@@ -1,68 +1,27 @@
-"use client"
-import React, { useState, useEffect } from "react";
-import ProjectCard from "@/app/ui/ProjectCard/ProjectCard";
-import ProjectModal from "@/app/ui/ProjectModal/ProjectModal";
-import { repoData, repoObject } from "@/app/lib/definitions";
+import React from 'react';
+import Portfolio from '../ui/Portfolio/Portfolio';
+import { repoData } from '../lib/definitions';
+import { fetchRepoData } from '../lib/services/vercelPostgres';
 
-const Page: React.FC = () => {
-	
-	const [repoData, setRepoData] = useState<repoData>({});
-	const [currentRepo, setCurrentRepo] = useState<string>("");
-	const [displayModal, setDisplayModal] = useState(false);
-
-	// fetch data in useEffect, assign to repoData
-	useEffect(() => {
-		
-		const fetchRepos = async () => {
-			const res: Response = await fetch(`${window.location.origin}/api`);
-			if (res.ok) {
-				const data: repoData = await res.json();
-				setRepoData(data);
-			} else {
-				console.error("there was an error fetching the data: ", )
-			}
-		};
-		fetchRepos();
-	}, []);
-
-	const enableModal = (repoId: string) => {
-		changeCurrentRepo(repoId);
-		setDisplayModal(true);
+const fetchRepos = async () => {
+	try {
+		const res: repoData = await fetchRepoData();
+		return res;
+	} catch (err) {
+		console.error("there was an error fetching the data: ", err);
+		return {};
 	}
-
-	const disableModal = (e: any) => {
-		if (e.target === e.currentTarget) {
-			setDisplayModal(false);
-		}
-	}
-
-	const changeCurrentRepo = (repoId: string) => {
-		if (repoId !== currentRepo) {
-			setCurrentRepo(repoId);
-		}
-	}
-
-	return (
-		<div className="grid grid-cols-3 place-items-center gap-5">
-			{Array.from(Object.values(repoData)).map((repo: repoObject) => {
-				return (<ProjectCard
-									key={repo.id}
-									description={repo.description}
-									title={repo.name}
-									id={repo.id}
-									openModalHandler={enableModal}
-				/>)
-			})}
-			{displayModal &&
-				<ProjectModal
-					repoName={repoData[currentRepo].name}
-					readmeImgUrl="https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fimg.lovepik.com%2Ffree-png%2F20211125%2Flovepik-square-cat-yellow-cartoon-angry-expression-pack-png-image_401129516_wh1200.png&f=1&nofb=1&ipt=cdf15c3a9033e687ef79040236f78a7db6ffc70d91ec8df9ea1ebf8c9fd9c514&ipo=images"
-					closeModalHandler={disableModal}
-					readme={repoData[currentRepo].readme}
-				/>
-			}
-		</div>
-	)
 }
 
+
+const Page: React.FC = async () => {
+
+	const data = await fetchRepos();
+
+	return (
+		<>
+			<Portfolio repoDataPack={data}/>
+		</>
+	);
+}
 export default Page;

--- a/app/ui/NavBar/NavButton.tsx
+++ b/app/ui/NavBar/NavButton.tsx
@@ -1,5 +1,4 @@
 "use client"
-
 import React from 'react';
 import clsx from "clsx";
 import Link from "next/link";

--- a/app/ui/Portfolio/Portfolio.tsx
+++ b/app/ui/Portfolio/Portfolio.tsx
@@ -1,0 +1,63 @@
+"use client"
+import React, { useState, useEffect } from "react";
+import { repoData, repoObject } from "@/app/lib/definitions";
+import ProjectCard from "@/app/ui/ProjectCard/ProjectCard";
+import ProjectModal from "@/app/ui/ProjectModal/ProjectModal";
+
+interface PortfolioProps {
+	repoDataPack: repoData
+}
+
+const Portfolio: React.FC<PortfolioProps> = ({ repoDataPack }) => {
+	const [repoData, _setRepoData] = useState<repoData>(repoDataPack);
+	const [currentRepo, setCurrentRepo] = useState<string>("");
+	const [displayModal, setDisplayModal] = useState(false);
+
+	useEffect(() => {
+		const fetchRepos = async () => {
+			
+		};
+		fetchRepos();
+	}, []);
+
+	const enableModal = (repoId: string) => {
+		changeCurrentRepo(repoId);
+		setDisplayModal(true);
+	}
+
+	const disableModal = (e: any) => {
+		if (e.target === e.currentTarget) {
+			setDisplayModal(false);
+		}
+	}
+
+	const changeCurrentRepo = (repoId: string) => {
+		if (repoId !== currentRepo) {
+			setCurrentRepo(repoId);
+		}
+	}
+
+	return (
+		<div className="grid grid-cols-3 place-items-center gap-5">
+			{Array.from(Object.values(repoData)).map((repo: repoObject) => {
+				return (<ProjectCard
+									key={repo.id}
+									description={repo.description}
+									title={repo.name}
+									id={repo.id}
+									openModalHandler={enableModal}
+				/>)
+			})}
+			{displayModal &&
+				<ProjectModal
+					repoName={repoData[currentRepo].name}
+					readmeImgUrl="https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fimg.lovepik.com%2Ffree-png%2F20211125%2Flovepik-square-cat-yellow-cartoon-angry-expression-pack-png-image_401129516_wh1200.png&f=1&nofb=1&ipt=cdf15c3a9033e687ef79040236f78a7db6ffc70d91ec8df9ea1ebf8c9fd9c514&ipo=images"
+					closeModalHandler={disableModal}
+					readme={repoData[currentRepo].readme}
+				/>
+			}
+		</div>
+	)
+}
+
+export default Portfolio;

--- a/app/ui/Portfolio/Portfolio.tsx
+++ b/app/ui/Portfolio/Portfolio.tsx
@@ -9,7 +9,7 @@ interface PortfolioProps {
 }
 
 const Portfolio: React.FC<PortfolioProps> = ({ repoDataPack }) => {
-	const [repoData, _setRepoData] = useState<repoData>(repoDataPack);
+	const repoData: repoData = repoDataPack;
 	const [currentRepo, setCurrentRepo] = useState<string>("");
 	const [displayModal, setDisplayModal] = useState(false);
 

--- a/app/ui/ProjectCard/ProjectCard.tsx
+++ b/app/ui/ProjectCard/ProjectCard.tsx
@@ -1,4 +1,3 @@
-"use client"
 import React from "react";
 import ProjectCardDescription from "@/app/ui/ProjectCard/ProjectCardDescription";
 import ProjectCardTitle from "@/app/ui/ProjectCard/ProjectCardTitle";

--- a/app/ui/ProjectModal/ProjectModal.tsx
+++ b/app/ui/ProjectModal/ProjectModal.tsx
@@ -1,4 +1,3 @@
-"use client"
 import React from "react";
 import { useState } from "react";
 import ProjectCardTitle from "@/app/ui/ProjectCard/ProjectCardTitle";


### PR DESCRIPTION
Previously, `portfolio/page.tsx` was defined as a client component, and data was fetch using a useEffect to fetch from the backend. This PR reverts `portfolio/page.tsx` back to a server component and handles the data fetch from there. Client-side logic was moved into a wrapper component and handed to `portfolio/page.tsx`.