### PR TITLE
Feature/server fetch repo data

### DIFF
--- a/app/api/fetchrepos/route.ts
+++ b/app/api/fetchrepos/route.ts
@@ -1,0 +1,7 @@
+import { retrieveRepos } from "@/app/lib/services/githubApi"
+import { repoData } from "@/app/lib/definitions";
+
+export async function GET() {
+  const data: repoData = await retrieveRepos();
+  return Response.json({ data })
+}

--- a/app/portfolio/page.tsx
+++ b/app/portfolio/page.tsx
@@ -1,10 +1,9 @@
 import React from 'react';
 import Portfolio from '../ui/Portfolio/Portfolio';
-import { repoData } from '../lib/definitions';
 
 const fetchRepos = async () => {
 	try {
-		const res: repoData = await fetch("http://localhost:3000/api/fetchrepos", {
+		const res: Response = await fetch("http://localhost:3000/api/fetchrepos", {
 			next: { revalidate: (60 * 60 * 24) }, 
 		});
 		const data = await res.json();

--- a/app/portfolio/page.tsx
+++ b/app/portfolio/page.tsx
@@ -1,12 +1,14 @@
 import React from 'react';
 import Portfolio from '../ui/Portfolio/Portfolio';
 import { repoData } from '../lib/definitions';
-import { retrieveRepos } from '../lib/services/githubApi';
 
 const fetchRepos = async () => {
 	try {
-		const res: repoData = await retrieveRepos();
-		return res;
+		const res: repoData = await fetch("http://localhost:3000/api/fetchrepos", {
+			next: { revalidate: (60 * 60 * 24) }, 
+		});
+		const data = await res.json();
+		return data.data;
 	} catch (err) {
 		console.error("there was an error fetching the data: ", err);
 		return undefined;


### PR DESCRIPTION
I wasn't sure if the Octokit.request object implements nextJS's caching system. The function that calls the github api with Octokit and performs some transformations has been moved to GET `api/fetchrepos` and called from the `api/Portfolio/page.tsx`. the `fetch` will cache this result and revalidate every 24 hours.

unsure if this is the most appropriate way to cache a response from a 3rd party package but it's not throwing any issues